### PR TITLE
update!: change defaults to not empty list but null if not specified

### DIFF
--- a/src/main/java/com/github/sttk/cliargs/CliArgs.java
+++ b/src/main/java/com/github/sttk/cliargs/CliArgs.java
@@ -105,12 +105,21 @@ public class CliArgs {
 
   /**
    * Is the exception reason which indicates that an option configuration
-   * contradicts that the option must be an array ({@code .isArray == true})
+   * contradicts that the option is an array ({@code .isArray == true})
    * though it has no option argument ({@code .hasArg == false}).
    *
    * @param storeKey  A store key.
    */
   public record ConfigIsArrayButHasNoArg(String storeKey) {}
+
+  /**
+   * Is the exception reason which indicates that an option configuration
+   * contradicts that the option is not an array ({@code .isArray == false})
+   * but default value ({@code .defaults} is an array.
+   *
+   * @param storeKey  A store key.
+   */
+  public record ConfigIsNotArrayButDefaultsIsArray(String storeKey) {}
 
   /**
    * Is the exception reason which indicates that an opiton configuration
@@ -219,7 +228,7 @@ public class CliArgs {
    * of which {@code storeKey} or the first element of {@code names} is
    * {@code "*"}.
    *
-   * @param optCfgs  An array of {@code OptCfg} objects.
+   * @param optCfgs  An array of {@link OptCfg} objects.
    * @return  A {@link Result} object that contains the parsed result.
    */
   public Result parseWith(OptCfg[] optCfgs) {

--- a/src/main/java/com/github/sttk/cliargs/ParseWith.java
+++ b/src/main/java/com/github/sttk/cliargs/ParseWith.java
@@ -162,8 +162,8 @@ interface ParseWith {
         list = new ArrayList<>();
         opts.put(storeKey, list);
       }
-      if (cfg.converter != null) {
-        if (cfg.hasArg) {
+      if (cfg.hasArg) {
+        if (cfg.converter != null) {
           try {
             list.add(cfg.converter.convert(arg, name, storeKey));
           } catch (ReasonedException e) {
@@ -172,9 +172,7 @@ interface ParseWith {
             var reason = new FailToConvertOptionArg(arg, name, storeKey);
             throw new ReasonedException(reason, e);
           }
-        }
-      } else {
-        if (cfg.hasArg) {
+        } else {
           list.add(arg);
         }
       }

--- a/src/test/java/com/github/sttk/cliargs/CmdTest.java
+++ b/src/test/java/com/github/sttk/cliargs/CmdTest.java
@@ -25,12 +25,9 @@ public class CmdTest {
     assertThat(cmd.getName()).isEqualTo("foo");
     assertThat(cmd.getArgs()).containsExactly("a0", "a1", "a2");
 
-    @SuppressWarnings("unchecked")
-    var o0 = (List<Integer>) cmd.getOptArgs("o0");
-    @SuppressWarnings("unchecked")
-    var o1 = (List<?>) cmd.getOptArgs("o1");
-    @SuppressWarnings("unchecked")
-    var o2 = (List<?>) cmd.getOptArgs("o2");
+    List<Integer> o0 = cmd.getOptArgs("o0");
+    List<?> o1 = cmd.getOptArgs("o1");
+    List<?> o2 = cmd.getOptArgs("o2");
     assertThat(o0).containsExactly(123, 456);
     assertThat(o1).isEmpty();
     assertThat(o2).isEmpty();
@@ -60,12 +57,9 @@ public class CmdTest {
 
     var cmd = new Cmd("foo", args, opts);
 
-    @SuppressWarnings("unchecked")
-    var o0 = (Integer) cmd.getOptArg("o0");
-    @SuppressWarnings("unchecked")
-    var o1 = (Integer) cmd.getOptArg("o1");
-    @SuppressWarnings("unchecked")
-    var o2 = (Integer) cmd.getOptArg("o2");
+    Integer o0 = cmd.getOptArg("o0");
+    Integer o1 = cmd.getOptArg("o1");
+    Integer o2 = cmd.getOptArg("o2");
     assertThat(o0).isEqualTo(123);
     assertThat(o1).isNull();
     assertThat(o2).isNull();
@@ -81,18 +75,16 @@ public class CmdTest {
 
     var cmd = new Cmd("foo", args, opts);
 
-    @SuppressWarnings("unchecked")
-    var o0 = (List<Integer>) cmd.getOptArgs("o0");
-    @SuppressWarnings("unchecked")
-    var o1 = (List<String>) cmd.getOptArgs("o1");
-    @SuppressWarnings("unchecked")
-    var o2 = (List<Object>) cmd.getOptArgs("o2");
+    List<Integer> o0 = cmd.getOptArgs("o0");
+    List<String> o1 = cmd.getOptArgs("o1");
+    List<Object> o2 = cmd.getOptArgs("o2");
     assertThat(o0).containsExactly(123, 456);
     assertThat(o1).isEmpty();
     assertThat(o2).isEmpty();
 
     try {
       o0.add(789);
+      fail();
     } catch (UnsupportedOperationException e) {}
   }
 
@@ -106,12 +98,9 @@ public class CmdTest {
 
     var cmd = new Cmd("foo", args, opts);
 
-    @SuppressWarnings("unchecked")
-    var o0 = (List<Integer>) cmd.getOptArgs("o0");
-    @SuppressWarnings("unchecked")
-    var o1 = (List<String>) cmd.getOptArgs("o1");
-    @SuppressWarnings("unchecked")
-    var o2 = (List<Object>) cmd.getOptArgs("o2");
+    List<Integer> o0 = cmd.getOptArgs("o0");
+    List<String> o1 = cmd.getOptArgs("o1");
+    List<Object> o2 = cmd.getOptArgs("o2");
     assertThat(o0).containsExactly(123, 456);
     assertThat(o1).isEmpty();
     assertThat(o2).isEmpty();
@@ -119,6 +108,7 @@ public class CmdTest {
     var a = cmd.getArgs();
     try {
       a.add("xxx");
+      fail();
     } catch (UnsupportedOperationException e) {}
   }
 }

--- a/src/test/java/com/github/sttk/cliargs/OptCfgTest.java
+++ b/src/test/java/com/github/sttk/cliargs/OptCfgTest.java
@@ -20,7 +20,7 @@ import java.time.OffsetDateTime;
 public class OptCfgTest {
 
   @Test
-  void testNormalConstructor() {
+  void testNormalConstructor_full() {
     var converter = new IntConverter();
     Postparser<Integer> postparser = i -> {};
 
@@ -52,6 +52,36 @@ public class OptCfgTest {
   }
 
   @Test
+  void testNormalConstructor_null() {
+    var converter = new IntConverter();
+    Postparser<Integer> postparser = i -> {};
+
+    var optCfg = new OptCfg(
+      null,
+      null,
+      false,
+      false,
+      null,
+      null,
+      null,
+      null,
+      null,
+      null
+    );
+
+    assertThat(optCfg.storeKey).isNull();
+    assertThat(optCfg.names).isEmpty();
+    assertThat(optCfg.hasArg).isFalse();
+    assertThat(optCfg.isArray).isFalse();
+    assertThat(optCfg.type).isNull();
+    assertThat(optCfg.defaults).isNull();
+    assertThat(optCfg.desc).isNull();
+    assertThat(optCfg.argInHelp).isNull();
+    assertThat(optCfg.converter).isNull();
+    assertThat(optCfg.postparser).isNull();
+  }
+
+  @Test
   void testConstructor_withNoNamedParam() {
     var optCfg = new OptCfg();
 
@@ -60,7 +90,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -77,7 +107,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -94,7 +124,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -111,7 +141,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -128,7 +158,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -145,7 +175,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -162,7 +192,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -179,7 +209,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -196,7 +226,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isTrue();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -213,7 +243,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(byte.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(ByteConverter.class);
@@ -230,7 +260,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Byte.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(ByteConverter.class);
@@ -247,7 +277,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(short.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(ShortConverter.class);
@@ -264,7 +294,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Short.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(ShortConverter.class);
@@ -281,7 +311,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(int.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(IntConverter.class);
@@ -298,7 +328,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Integer.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(IntConverter.class);
@@ -315,7 +345,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(long.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(LongConverter.class);
@@ -332,7 +362,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Long.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(LongConverter.class);
@@ -349,7 +379,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(float.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(FloatConverter.class);
@@ -366,7 +396,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Float.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(FloatConverter.class);
@@ -383,7 +413,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(double.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(DoubleConverter.class);
@@ -400,7 +430,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Double.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isInstanceOf(DoubleConverter.class);
@@ -414,10 +444,10 @@ public class OptCfgTest {
 
     assertThat(optCfg.storeKey).isNull();
     assertThat(optCfg.names).isEmpty();
-    assertThat(optCfg.hasArg).isTrue();
+    assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(boolean.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -431,10 +461,10 @@ public class OptCfgTest {
 
     assertThat(optCfg.storeKey).isNull();
     assertThat(optCfg.names).isEmpty();
-    assertThat(optCfg.hasArg).isTrue();
+    assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(Boolean.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -451,7 +481,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(String.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -468,7 +498,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isTrue();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isEqualTo(OffsetDateTime.class);
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -523,7 +553,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isEqualTo("option desc");
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();
@@ -540,7 +570,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isEqualTo("<num>");
     assertThat(optCfg.converter).isNull();
@@ -559,7 +589,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isEqualTo(c);
@@ -578,7 +608,7 @@ public class OptCfgTest {
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();
-    assertThat(optCfg.defaults).isEmpty();
+    assertThat(optCfg.defaults).isNull();
     assertThat(optCfg.desc).isNull();
     assertThat(optCfg.argInHelp).isNull();
     assertThat(optCfg.converter).isNull();

--- a/src/test/java/com/github/sttk/cliargs/ParseTest.java
+++ b/src/test/java/com/github/sttk/cliargs/ParseTest.java
@@ -124,8 +124,7 @@ public class ParseTest {
     assertThat((String)cmd.getOptArg("silent")).isNull();
 
     assertThat((List<?>)cmd.getOptArgs("a")).isEmpty();
-    @SuppressWarnings("unchecked")
-    var alphabet = (List<String>)cmd.getOptArgs("alphabet");
+    List<String> alphabet = cmd.getOptArgs("alphabet");
     assertThat(alphabet).containsExactly("ABC");
     assertThat((List<?>)cmd.getOptArgs("s")).isEmpty();
     assertThat((List<?>)cmd.getOptArgs("silent")).isEmpty();
@@ -183,8 +182,7 @@ public class ParseTest {
     assertThat((String)cmd.getOptArg("s")).isNull();
     assertThat((String)cmd.getOptArg("silent")).isNull();
 
-    @SuppressWarnings("unchecked")
-    var a = (List<String>)cmd.getOptArgs("a");
+    List<String> a = cmd.getOptArgs("a");
     assertThat(a).containsExactly("123");
     assertThat((List<?>)cmd.getOptArgs("alphabet")).isEmpty();
     assertThat((List<?>)cmd.getOptArgs("s")).isEmpty();
@@ -243,8 +241,7 @@ public class ParseTest {
     assertThat((String)cmd.getOptArg("s")).isNull();
     assertThat((String)cmd.getOptArg("silent")).isNull();
 
-    @SuppressWarnings("unchecked")
-    var a = (List<String>)cmd.getOptArgs("a");
+    List<String> a = cmd.getOptArgs("a");
     assertThat(a).containsExactly("123");
     assertThat((List<?>)cmd.getOptArgs("alphabet")).isEmpty();
     assertThat((List<?>)cmd.getOptArgs("s")).isEmpty();
@@ -266,8 +263,7 @@ public class ParseTest {
 
     assertThat(cmd.hasOpt("aaa-bbb-ccc")).isTrue();
     assertThat((String)cmd.getOptArg("aaa-bbb-ccc")).isEqualTo("123");
-    @SuppressWarnings("unchecked")
-    var aaaBbbCcc = (List<String>)cmd.getOptArgs("aaa-bbb-ccc");
+    List<String> aaaBbbCcc = cmd.getOptArgs("aaa-bbb-ccc");
     assertThat(aaaBbbCcc).containsExactly("123");
   }
 
@@ -287,8 +283,7 @@ public class ParseTest {
     assertThat(cmd.hasOpt("a")).isTrue();
     assertThat((String)cmd.getOptArg("a")).isEqualTo("b=c");
 
-    @SuppressWarnings("unchecked")
-    var a = (List<String>)cmd.getOptArgs("a");
+    List<String> a = cmd.getOptArgs("a");
     assertThat(a).containsExactly("b=c");
   }
 
@@ -307,8 +302,7 @@ public class ParseTest {
 
     assertThat(cmd.hasOpt("a")).isTrue();
     assertThat((String)cmd.getOptArg("a")).isEqualTo("1,2-3");
-    @SuppressWarnings("unchecked")
-    var a = (List<String>)cmd.getOptArgs("a");
+    List<String> a = cmd.getOptArgs("a");
     assertThat(a).containsExactly("1,2-3");
   }
 
@@ -540,8 +534,7 @@ public class ParseTest {
 
     assertThat((List<?>)cmd.getOptArgs("a")).isEmpty();
     assertThat((List<?>)cmd.getOptArgs("b")).isEmpty();
-    @SuppressWarnings("unchecked")
-    var c = (List<String>)cmd.getOptArgs("c");
+    List<String> c = cmd.getOptArgs("c");
     assertThat(c).containsExactly("3", "4");
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat((List<?>)cmd.getOptArgs("baz")).isEmpty();

--- a/src/test/java/com/github/sttk/cliargs/ParseWithTest.java
+++ b/src/test/java/com/github/sttk/cliargs/ParseWithTest.java
@@ -15,6 +15,7 @@ import static com.github.sttk.cliargs.OptCfg.NamedParam.postparser;
 import com.github.sttk.exception.ReasonedException;
 import com.github.sttk.cliargs.CliArgs.ConfigHasDefaultsButHasNoArg;
 import com.github.sttk.cliargs.CliArgs.ConfigIsArrayButHasNoArg;
+import com.github.sttk.cliargs.CliArgs.ConfigIsNotArrayButDefaultsIsArray;
 import com.github.sttk.cliargs.CliArgs.FailToConvertOptionArg;
 import com.github.sttk.cliargs.CliArgs.StoreKeyIsDuplicated;
 import com.github.sttk.cliargs.CliArgs.UnconfiguredOption;
@@ -874,6 +875,72 @@ public class ParseWithTest {
     assertThat(exc).isNotNull();
     switch (exc.getReason()) {
       case ConfigIsArrayButHasNoArg r -> {
+        assertThat(r.storeKey()).isEqualTo("foo-bar");
+      }
+      default -> fail(exc);
+    }
+
+    var cmd = result.cmd();
+    assertThat(cmd.getName()).isEqualTo("app");
+    assertThat(cmd.hasOpt("foo-bar")).isFalse();
+    assertThat((String)cmd.getOptArg("foo-bar")).isNull();
+    assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
+    assertThat(cmd.hasOpt("f")).isFalse();
+    assertThat((String)cmd.getOptArg("f")).isNull();
+    assertThat((List<?>)cmd.getOptArgs("f")).isEmpty();
+    assertThat(cmd.getArgs()).isEmpty();
+  }
+
+  @Test
+  void testParseWith_oneCfgIsNotArrayButHasDefaultsIsEmpty() {
+    @SuppressWarnings("unchecked")
+    var cfgs = new OptCfg[]{
+      new OptCfg(names("foo-bar"), hasArg(true), defaults())
+    };
+
+    var args = new String[]{"--foo-bar", "ABC"};
+    var cliargs = new CliArgs("app", args);
+    var result = cliargs.parseWith(cfgs);
+
+    assertThat(result.optCfgs()).isEqualTo(cfgs);
+
+    var exc = result.exception();
+    assertThat(exc).isNotNull();
+    switch (exc.getReason()) {
+      case ConfigIsNotArrayButDefaultsIsArray r -> {
+        assertThat(r.storeKey()).isEqualTo("foo-bar");
+      }
+      default -> fail(exc);
+    }
+
+    var cmd = result.cmd();
+    assertThat(cmd.getName()).isEqualTo("app");
+    assertThat(cmd.hasOpt("foo-bar")).isFalse();
+    assertThat((String)cmd.getOptArg("foo-bar")).isNull();
+    assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
+    assertThat(cmd.hasOpt("f")).isFalse();
+    assertThat((String)cmd.getOptArg("f")).isNull();
+    assertThat((List<?>)cmd.getOptArgs("f")).isEmpty();
+    assertThat(cmd.getArgs()).isEmpty();
+  }
+
+  @Test
+  void testParseWith_oneCfgIsNotArrayButHasArrayDefaultsIsMultiple() {
+    @SuppressWarnings("unchecked")
+    var cfgs = new OptCfg[]{
+      new OptCfg(names("foo-bar"), hasArg(true), defaults(1, 2))
+    };
+
+    var args = new String[]{"--foo-bar", "ABC"};
+    var cliargs = new CliArgs("app", args);
+    var result = cliargs.parseWith(cfgs);
+
+    assertThat(result.optCfgs()).isEqualTo(cfgs);
+
+    var exc = result.exception();
+    assertThat(exc).isNotNull();
+    switch (exc.getReason()) {
+      case ConfigIsNotArrayButDefaultsIsArray r -> {
         assertThat(r.storeKey()).isEqualTo("foo-bar");
       }
       default -> fail(exc);

--- a/src/test/java/com/github/sttk/cliargs/ParseWithTest.java
+++ b/src/test/java/com/github/sttk/cliargs/ParseWithTest.java
@@ -404,8 +404,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars0 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars0 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars0).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -424,8 +423,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars1 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars1 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars1).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -444,8 +442,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("");
-    @SuppressWarnings("unchecked")
-    var fooBar2 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBar2 = cmd.getOptArgs("foo-bar");
     assertThat(fooBar2).containsExactly("");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -464,8 +461,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("");
-    @SuppressWarnings("unchecked")
-    var fooBar3 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBar3 = cmd.getOptArgs("foo-bar");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
     assertThat((List<?>)cmd.getOptArgs("f")).isEmpty();
@@ -494,8 +490,7 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat(cmd.hasOpt("f")).isTrue();
     assertThat((String)cmd.getOptArg("f")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var f0 = (List<String>)cmd.getOptArgs("f");
+    List<String> f0 = cmd.getOptArgs("f");
     assertThat(f0).containsExactly("ABC");
     assertThat(cmd.getArgs()).isEmpty();
 
@@ -514,8 +509,7 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat(cmd.hasOpt("f")).isTrue();
     assertThat((String)cmd.getOptArg("f")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var f1 = (List<String>)cmd.getOptArgs("f");
+    List<String> f1 = cmd.getOptArgs("f");
     assertThat(f1).containsExactly("ABC");
     assertThat(cmd.getArgs()).isEmpty();
 
@@ -534,8 +528,7 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat(cmd.hasOpt("f")).isTrue();
     assertThat((String)cmd.getOptArg("f")).isEqualTo("");
-    @SuppressWarnings("unchecked")
-    var fooBar2 = (List<String>)cmd.getOptArgs("f");
+    List<String> fooBar2 = cmd.getOptArgs("f");
     assertThat(fooBar2).containsExactly("");
     assertThat(cmd.getArgs()).isEmpty();
 
@@ -554,8 +547,7 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat(cmd.hasOpt("f")).isTrue();
     assertThat((String)cmd.getOptArg("f")).isEqualTo("");
-    @SuppressWarnings("unchecked")
-    var fooBar3 = (List<String>)cmd.getOptArgs("f");
+    List<String> fooBar3 = cmd.getOptArgs("f");
     assertThat(cmd.getArgs()).isEmpty();
   }
 
@@ -917,8 +909,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars0 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars0 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars0).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -936,8 +927,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars1 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars1 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars1).containsExactly("ABC", "DEF");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -958,8 +948,7 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat(cmd.hasOpt("f")).isTrue();
     assertThat((String)cmd.getOptArg("f")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var f0 = (List<String>)cmd.getOptArgs("f");
+    List<String> f0 = cmd.getOptArgs("f");
     assertThat(f0).containsExactly("ABC");
     assertThat(cmd.getArgs()).isEmpty();
 
@@ -977,8 +966,7 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
     assertThat(cmd.hasOpt("f")).isTrue();
     assertThat((String)cmd.getOptArg("f")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var f1 = (List<String>)cmd.getOptArgs("f");
+    List<String> f1 = cmd.getOptArgs("f");
     assertThat(f1).containsExactly("ABC", "DEF");
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1001,8 +989,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars0 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars0 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars0).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1020,8 +1007,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars1 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars1 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars1).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1047,8 +1033,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars0 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars0 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars0).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1069,8 +1054,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars1 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars1 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars1).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1091,8 +1075,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars2 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars2 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars2).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1113,8 +1096,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars3 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars3 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars3).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1135,8 +1117,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars4 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars4 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars4).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1157,8 +1138,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars5 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars5 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars5).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1179,8 +1159,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars6 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars6 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars6).containsExactly("ABC", "DEF", "GHI");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1225,8 +1204,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo-bar")).isTrue();
     assertThat((String)cmd.getOptArg("foo-bar")).isEqualTo("ABC");
-    @SuppressWarnings("unchecked")
-    var fooBars6 = (List<String>)cmd.getOptArgs("foo-bar");
+    List<String> fooBars6 = cmd.getOptArgs("foo-bar");
     assertThat(fooBars6).containsExactly("ABC");
     assertThat(cmd.hasOpt("f")).isFalse();
     assertThat((String)cmd.getOptArg("f")).isNull();
@@ -1256,13 +1234,11 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("bar")).isTrue();
     assertThat((String)cmd.getOptArg("bar")).isEqualTo("A");
-    @SuppressWarnings("unchecked")
-    var bar0 = (List<String>)cmd.getOptArgs("bar");
+    List<String> bar0 = cmd.getOptArgs("bar");
     assertThat(bar0).containsExactly("A");
     assertThat(cmd.hasOpt("baz")).isTrue();
     assertThat((String)cmd.getOptArg("baz")).isEqualTo("B");
-    @SuppressWarnings("unchecked")
-    var baz0 = (List<String>)cmd.getOptArgs("baz");
+    List<String> baz0 = cmd.getOptArgs("baz");
     assertThat(baz0).containsExactly("B");
 
     args = new String[]{"--bar", "C"};
@@ -1276,13 +1252,11 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("bar")).isTrue();
     assertThat((String)cmd.getOptArg("bar")).isEqualTo("C");
-    @SuppressWarnings("unchecked")
-    var bar1 = (List<String>)cmd.getOptArgs("bar");
+    List<String> bar1 = cmd.getOptArgs("bar");
     assertThat(bar1).containsExactly("C");
     assertThat(cmd.hasOpt("baz")).isTrue();
     assertThat((String)cmd.getOptArg("baz")).isEqualTo("B");
-    @SuppressWarnings("unchecked")
-    var baz1 = (List<String>)cmd.getOptArgs("baz");
+    List<String> baz1 = cmd.getOptArgs("baz");
     assertThat(baz1).containsExactly("B");
   }
 
@@ -1348,11 +1322,9 @@ public class ParseWithTest {
     assertThat((String)cmd.getOptArg("baz")).isEqualTo("1");
     assertThat((String)cmd.getOptArg("corge")).isEqualTo("99");
     assertThat((List<?>)cmd.getOptArgs("foo-bar")).isEmpty();
-    @SuppressWarnings("unchecked")
-    var baz = (List<Object>)cmd.getOptArgs("baz");
+    List<String> baz = cmd.getOptArgs("baz");
     assertThat(baz).containsExactly("1", "2");
-    @SuppressWarnings("unchecked")
-    var corge = (List<Object>)cmd.getOptArgs("corge");
+    List<String> corge = cmd.getOptArgs("corge");
     assertThat(corge).containsExactly("99");
     assertThat(cmd.getArgs()).containsExactly("qux", "quux");
   }
@@ -1643,8 +1615,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("Bar")).isTrue();
     assertThat((String)cmd.getOptArg("Bar")).isEqualTo("1");
-    @SuppressWarnings("unchecked")
-    var foo = (List<String>)cmd.getOptArgs("Bar");
+    List<String> foo = cmd.getOptArgs("Bar");
     assertThat(foo).containsExactly("1", "2", "3");
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1667,8 +1638,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Byte)cmd.getOptArg("foo")).isEqualTo((byte)1);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Byte>)cmd.getOptArgs("foo");
+    List<Byte> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly((byte)1);
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1691,8 +1661,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Short)cmd.getOptArg("foo")).isEqualTo((short)1);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Short>)cmd.getOptArgs("foo");
+    List<Short> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly((short)1);
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1715,8 +1684,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Integer)cmd.getOptArg("foo")).isEqualTo(1);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Integer>)cmd.getOptArgs("foo");
+    List<Integer> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly(1);
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1739,8 +1707,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Long)cmd.getOptArg("foo")).isEqualTo(1L);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Long>)cmd.getOptArgs("foo");
+    List<Long> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly((long)1);
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1763,8 +1730,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Float)cmd.getOptArg("foo")).isEqualTo(1.0f);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Float>)cmd.getOptArgs("foo");
+    List<Float> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly(1.0f);
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1787,8 +1753,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Double)cmd.getOptArg("foo")).isEqualTo(1.0);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Double>)cmd.getOptArgs("foo");
+    List<Double> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly(1.0);
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1812,8 +1777,7 @@ public class ParseWithTest {
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((BigInteger)cmd.getOptArg("foo"))
       .isEqualTo(new BigInteger("1"));
-    @SuppressWarnings("unchecked")
-    var foo = (List<BigInteger>)cmd.getOptArgs("foo");
+    List<BigInteger> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly(new BigInteger("1"));
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1837,8 +1801,7 @@ public class ParseWithTest {
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((BigDecimal)cmd.getOptArg("foo"))
       .isEqualTo(new BigDecimal("1"));
-    @SuppressWarnings("unchecked")
-    var foo = (List<BigDecimal>)cmd.getOptArgs("foo");
+    List<BigDecimal> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly(new BigDecimal("1"));
     assertThat(cmd.getArgs()).isEmpty();
   }
@@ -1863,8 +1826,7 @@ public class ParseWithTest {
     assertThat(cmd.getName()).isEqualTo("app");
     assertThat(cmd.hasOpt("foo")).isTrue();
     assertThat((Integer)cmd.getOptArg("foo")).isEqualTo(1);
-    @SuppressWarnings("unchecked")
-    var foo = (List<Integer>)cmd.getOptArgs("foo");
+    List<Integer> foo = cmd.getOptArgs("foo");
     assertThat(foo).containsExactly(1);
     assertThat(cmd.getArgs()).isEmpty();
   }


### PR DESCRIPTION
This PR changes `OptCfg.defaults` to not empty list but null if it is not specified. This is to enable to distinguish whether default values of  an option are specified an empty list or not specified. It is important for an array option. 