### PR TITLE
new: added CliArgs.findFirstArg

### DIFF
--- a/src/main/java/com/github/sttk/cliargs/CliArgs.java
+++ b/src/main/java/com/github/sttk/cliargs/CliArgs.java
@@ -12,6 +12,7 @@ import com.github.sttk.cliargs.annotation.Opt;
 import com.github.sttk.exception.ReasonedException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Provides the static methods to parse and print command line arguments.
@@ -350,5 +351,31 @@ public class CliArgs {
     Object options
   ) throws ReasonedException {
     return ParseFor.makeOptCfgsFor(options);
+  }
+
+  /**
+   * Finds the index of the first non option-format element in a specified string
+   * array.
+   * If non option-format element is not found, this method return a negative
+   * integer.
+   * If {@code "--"} is found before finding non option-format element, the next
+   * index is always returned if its element starts with hyphens.
+   *
+   * @param args  A string array from command line arguments.
+   * @return  The index of the first non option element.
+   */
+  public static int findFirstArg(String ...args) {
+    boolean isNonOpt = false;
+    for (int i = 0; i < args.length; i++) {
+      if (isNonOpt) {
+        return i;
+      } else if (Objects.equals(args[i], "--")) {
+        isNonOpt = true;
+        continue;
+      } else if (! args[i].startsWith("-")) {
+        return i;
+      }
+    }
+    return -1;
   }
 }

--- a/src/test/java/com/github/sttk/cliargs/FindFirstArgTest.java
+++ b/src/test/java/com/github/sttk/cliargs/FindFirstArgTest.java
@@ -1,0 +1,62 @@
+package com.github.sttk.cliargs;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.fail;
+import org.junit.jupiter.api.Test;
+
+@SuppressWarnings("missing-explicit-ctor")
+public class FindFirstArgTest {
+
+  @Test
+  void testFindFirstArg_findAtFirstIndex() {
+    var args = new String[]{"foo-bar", "-a", "--baz", "--bcd"};
+
+    int i = CliArgs.findFirstArg(args);
+    assertThat(i).isEqualTo(0);
+    assertThat(args[i]).isEqualTo("foo-bar");
+  }
+
+  @Test
+  void testFindFirstArg_findAtMiddleIndex() {
+    var args = new String[]{"--corge", "foo-bar", "-a", "--baz", "--bcd"};
+
+    int i = CliArgs.findFirstArg(args);
+    assertThat(i).isEqualTo(1);
+    assertThat(args[i]).isEqualTo("foo-bar");
+  }
+
+  @Test
+  void tstFindFirstArg_findAtLastIndex() {
+    var args = new String[]{"--corge", "--foo-bar", "-a", "baz"};
+
+    int i = CliArgs.findFirstArg(args);
+    assertThat(i).isEqualTo(3);
+    assertThat(args[i]).isEqualTo("baz");
+  }
+
+  @Test
+  void testFindFirstArg_returnFoundFirst() {
+    var args = new String[]{"--corge", "foo-bar", "-a", "baz", "--bcd"};
+
+    int i = CliArgs.findFirstArg(args);
+    assertThat(i).isEqualTo(1);
+    assertThat(args[i]).isEqualTo("foo-bar");
+  }
+
+  @Test
+  void testFindFirstArg_notFound() {
+    var args = new String[]{"--corge", "--foo-bar", "-a", "--baz", "--bcd"};
+
+    int i = CliArgs.findFirstArg(args);
+    assertThat(i).isEqualTo(-1);
+  }
+
+  @Test
+  void testFindFirstArg_supportDoubleHyphens() {
+    var args = new String[]{"--corge", "--foo-bar", "--", "--baz", "--bcd"};
+
+    int i = CliArgs.findFirstArg(args);
+    assertThat(i).isEqualTo(3);
+    assertThat(args[i]).isEqualTo("--baz");
+  }
+}


### PR DESCRIPTION
This PR adds the static method `CliArgs.findFirstArg` which returns the index of the first non-option argument.
This static method is useful to parse command line argument with supporting sub-command.