### PR TITLE
cicd: copied resource-config.json to native-image directory for test

### DIFF
--- a/.ci/macos-latest/resource-config.json
+++ b/.ci/macos-latest/resource-config.json
@@ -1,7 +1,7 @@
 {
   "resources":{
   "includes":[{
-    "pattern":"\\Qcom/sun/jna/darwin-x86-64/libjnidispatch.jnilib\\E"
+    "pattern":"\\Qcom/sun/jna/darwin-aarch64/libjnidispatch.jnilib\\E"
   }]},
   "bundles":[]
 }

--- a/.github/workflows/java-ci.yml
+++ b/.github/workflows/java-ci.yml
@@ -24,7 +24,8 @@ jobs:
         native-image-job-reports: 'true'
     - name: Build and test
       run: mvn package
-    - name: Test with trace agent
-      run: mvn -Ptrace test
+    - name: Prepare  native test
+      run: |
+        cp .ci/${{ matrix.os }}/resource-config.json src/test/resources/META-INF/native-image/
     - name: Native test
       run: mvn -Pnative test


### PR DESCRIPTION
This description follows that of **linebreak-java**.