### PR TITLE
update: use blank option names in OptCfg as indent in help

### DIFF
--- a/src/main/java/com/github/sttk/cliargs/OptCfg.java
+++ b/src/main/java/com/github/sttk/cliargs/OptCfg.java
@@ -6,6 +6,7 @@
 package com.github.sttk.cliargs;
 
 import static com.github.sttk.cliargs.Util.isEmpty;
+import static com.github.sttk.cliargs.Util.isBlank;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.emptyList;
 
@@ -210,17 +211,18 @@ public class OptCfg {
   }
 
   private void fillmissing(Init<?> init) {
+    List<String> nonBlankNames = (init.names == null) ? null :
+      init.names.stream().filter(s -> !isBlank(s)).toList();
+
     if (isEmpty(init.storeKey)) {
-      if (! isEmpty(init.names)) {
-        init.storeKey = init.names.get(0);
+      if (! isEmpty(nonBlankNames)) {
+        init.storeKey = nonBlankNames.get(0);
       }
     } else {
-      if (isEmpty(init.names)) {
-        init.names = new ArrayList<String>();
+      if (isEmpty(nonBlankNames)) {
+        init.names = (init.names == null) ? new ArrayList<String>() :
+          new ArrayList<String>(init.names);
         init.names.add(init.storeKey);
-      } else if (isEmpty(init.names.get(0))) {
-        init.names = new ArrayList<String>(init.names);
-        init.names.set(0, init.storeKey);
       }
     }
 

--- a/src/main/java/com/github/sttk/cliargs/Util.java
+++ b/src/main/java/com/github/sttk/cliargs/Util.java
@@ -20,4 +20,8 @@ interface Util {
   static boolean isEmpty(List<?> list) {
     return (list == null || list.isEmpty());
   }
+
+  static boolean isBlank(String value) {
+    return (value == null || value.isBlank());
+  }
 }

--- a/src/test/java/com/github/sttk/cliargs/OptCfgTest.java
+++ b/src/test/java/com/github/sttk/cliargs/OptCfgTest.java
@@ -183,12 +183,29 @@ public class OptCfgTest {
   }
 
   @Test
-  void testConstructor_withNamedParam_firstElemOfNamesIsEmpty() {
+  void testConstructor_withNamedParam_acceptBlankNames() {
     @SuppressWarnings("unchecked")
-    var optCfg = new OptCfg(storeKey("FooBar"), names("", "f"));
+    var optCfg = new OptCfg(storeKey("FooBar"), names("", " ", "f"));
 
     assertThat(optCfg.storeKey).isEqualTo("FooBar");
-    assertThat(optCfg.names).containsExactly("FooBar", "f");
+    assertThat(optCfg.names).containsExactly("", " ", "f");
+    assertThat(optCfg.hasArg).isFalse();
+    assertThat(optCfg.isArray).isFalse();
+    assertThat(optCfg.type).isNull();
+    assertThat(optCfg.defaults).isNull();
+    assertThat(optCfg.desc).isNull();
+    assertThat(optCfg.argInHelp).isNull();
+    assertThat(optCfg.converter).isNull();
+    assertThat(optCfg.postparser).isNull();
+  }
+
+  @Test
+  void testConstructor_withNamedParam_notSetBlankNameToStoreKey() {
+    @SuppressWarnings("unchecked")
+    var optCfg = new OptCfg(names("  ", "foo-bar", "f"));
+
+    assertThat(optCfg.storeKey).isEqualTo("foo-bar");
+    assertThat(optCfg.names).containsExactly("  ", "foo-bar", "f");
     assertThat(optCfg.hasArg).isFalse();
     assertThat(optCfg.isArray).isFalse();
     assertThat(optCfg.type).isNull();

--- a/src/test/java/com/github/sttk/cliargs/ParseWithTest.java
+++ b/src/test/java/com/github/sttk/cliargs/ParseWithTest.java
@@ -2121,4 +2121,58 @@ public class ParseWithTest {
     assertThat((List<?>)cmd.getOptArgs("foo")).isEmpty();
     assertThat(cmd.getArgs()).isEmpty();
   }
+
+  @Test
+  void testParseWith_notToSetBlankNameInNamesToStoreKey() {
+    @SuppressWarnings("unchecked")
+    var cfgs = new OptCfg[]{
+      new OptCfg(
+        names(" ", "foo", "f"),
+        hasArg(true),
+        isArray(true)
+      )
+    };
+
+    var args = new String[] {"--foo", "A", "-f", "B"};
+    var cliargs = new CliArgs("app", args);
+    var result = cliargs.parseWith(cfgs);
+
+    assertThat(result.optCfgs()).isEqualTo(cfgs);
+    assertThat(result.exception()).isNull();
+
+    var cmd = result.cmd();
+    assertThat(cmd.getName()).isEqualTo("app");
+    assertThat(cmd.hasOpt("foo")).isTrue();
+    assertThat((String)cmd.getOptArg("foo")).isEqualTo("A");
+    List<String> foo = cmd.getOptArgs("foo");
+    assertThat(foo).containsExactly("A", "B");
+    assertThat(cmd.getArgs()).isEmpty();
+  }
+
+  @Test
+  void testParseWith_addStoreKeyToNamesIsSpecifiedNamesAreAllBlank() {
+    @SuppressWarnings("unchecked")
+    var cfgs = new OptCfg[]{
+      new OptCfg(
+        storeKey("foo"),
+        names(" ", "  ", "   "),
+        hasArg(true)
+      )
+    };
+
+    var args = new String[] {"--foo", "A"};
+    var cliargs = new CliArgs("app", args);
+    var result = cliargs.parseWith(cfgs);
+
+    assertThat(result.optCfgs()).isEqualTo(cfgs);
+    assertThat(result.exception()).isNull();
+
+    var cmd = result.cmd();
+    assertThat(cmd.getName()).isEqualTo("app");
+    assertThat(cmd.hasOpt("foo")).isTrue();
+    assertThat((String)cmd.getOptArg("foo")).isEqualTo("A");
+    List<String> foo = cmd.getOptArgs("foo");
+    assertThat(foo).containsExactly("A");
+    assertThat(cmd.getArgs()).isEmpty();
+  }
 }

--- a/src/test/java/com/github/sttk/cliargs/UtilTest.java
+++ b/src/test/java/com/github/sttk/cliargs/UtilTest.java
@@ -1,6 +1,7 @@
 package com.github.sttk.cliargs;
 
 import static com.github.sttk.cliargs.Util.isEmpty;
+import static com.github.sttk.cliargs.Util.isBlank;
 import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import java.util.List;
@@ -30,5 +31,15 @@ public class UtilTest {
     assertThat(isEmpty(List.of(""))).isFalse();
     assertThat(isEmpty(new ArrayList<String>())).isTrue();
     assertThat(isEmpty((List<Integer>) null)).isTrue();
+  }
+
+  @Test
+  void testIsBlank_string() {
+    assertThat(isBlank("abc")).isFalse();
+    assertThat(isBlank("")).isTrue();
+    assertThat(isBlank((String)null)).isTrue();
+    assertThat(isBlank(" ")).isTrue();
+    assertThat(isBlank("　")).isTrue();
+    assertThat(isBlank("\t")).isTrue();
   }
 }


### PR DESCRIPTION
Resolves #10 